### PR TITLE
fix missing $this->execute() in findUserByEmail

### DIFF
--- a/mvcloginregister/app/libraries/Database.php
+++ b/mvcloginregister/app/libraries/Database.php
@@ -65,6 +65,7 @@
 
         //Get's the row count
         public function rowCount() {
+            $this->execute();
             return $this->statement->rowCount();
         }
     }


### PR DESCRIPTION
As said by Remi in a youtube comment:
Great tutorial! I found a bug in your script in the register part. When you check if the email is already in the database you use the findUserByEmail function, but that function that always returns false. I checked and the rowCount() always returns 0. This is because you didn't perform an execute. If you go to app/libraries/Database.php add $this->execute(); to the public function rowCount() and everything should work fine.